### PR TITLE
Change Canasta image source

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,9 +15,7 @@ services:
       - mysql-data-volume:/var/lib/mysql
 
   web:
-    build:
-      dockerfile: Dockerfile
-      context: .
+    image: ghcr.io/wikiworks/canasta:latest
     restart: unless-stopped
     ports:
       - "${PORT:-80}:80"

--- a/kubernetes/web.yaml
+++ b/kubernetes/web.yaml
@@ -40,7 +40,7 @@ spec:
               value: 10M
             - name: PHP_UPLOAD_MAX_FILESIZE
               value: 10M
-          image: ghcr.io/wikiteq/canasta:latest
+          image: ghcr.io/wikiworks/canasta:latest
           imagePullPolicy: Always
           name: web
           ports:


### PR DESCRIPTION
Changes default source for `web` image to `ghcr.io/wikiworks/canasta:latest` so `docker-compose up -d` doesn't result in building forever for new users