### PR TITLE
Remove the security-related globals

### DIFF
--- a/_sources/canasta/CanastaUtils.php
+++ b/_sources/canasta/CanastaUtils.php
@@ -58,9 +58,3 @@ function cfLoadSkin( $skinName ) {
 	$wgStyleDirectory = $realStyleDirectory;
 	$wgStylePath = $realStylePath;
 }
-
-# Fixes CVE-2021-44858, CVE-2021-45038, CVE-2021-44857, https://www.mediawiki.org/wiki/2021-12_security_release/FAQ
-$wgActions['mcrundo'] = false;
-$wgActions['mcrrestore'] = false;
-$wgWhitelistRead = [];
-$wgWhitelistReadRegexp = [];


### PR DESCRIPTION
These were added to address CVE-2021-44858, CVE-2021-45038, CVE-2021-44857, but they are not needed any more, since the image uses 1.35.5.