### PR TITLE
Added patches for handling paths in chameleon skin

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -575,6 +575,16 @@ RUN set -x; \
     cd $MW_HOME/extensions/SocialProfile \
     && git apply /tmp/SocialProfile-disable-fields.patch
 
+COPY _sources/patches/bootstrap-path.patch /tmp/bootstrap-path.patch
+RUN set -x; \
+    cd $MW_HOME/extensions/Bootstrap \
+    && git apply /tmp/bootstrap-path.patch
+
+COPY _sources/patches/chameleon-path.patch /tmp/chameleon-path.patch
+RUN set -x; \
+    cd $MW_HOME/skins/chameleon \
+    && git apply /tmp/chameleon-path.patch
+
 # Cleanup all .git leftovers
 RUN set -x; \
     cd $MW_HOME \

--- a/_sources/patches/bootstrap-path.patch
+++ b/_sources/patches/bootstrap-path.patch
@@ -1,0 +1,16 @@
+diff --git a/src/Bootstrap.php b/src/Bootstrap.php
+index 235a717..0cfc92f 100644
+--- a/src/Bootstrap.php
++++ b/src/Bootstrap.php
+@@ -54,9 +54,9 @@ class Bootstrap {
+ 			$configuration = [];
+ 			$configuration[ 'IP' ] = $GLOBALS[ 'IP' ];
+ 			$configuration[ 'remoteBasePath' ] =
+-				$GLOBALS[ 'wgExtensionAssetsPath' ] . '/Bootstrap/resources/bootstrap';
++				$GLOBALS[ 'wgScriptPath' ] . '/canasta-extensions/Bootstrap/resources/bootstrap';
+ 			$configuration[ 'localBasePath' ] =
+-				$GLOBALS[ 'wgExtensionDirectory' ] . '/Bootstrap/resources/bootstrap';
++				$GLOBALS[ 'IP' ] . '/canasta-extensions/Bootstrap/resources/bootstrap';
+ 
+ 			$setupAfterCache = new SetupAfterCache( $configuration );
+ 			$setupAfterCache->process();

--- a/_sources/patches/chameleon-path.patch
+++ b/_sources/patches/chameleon-path.patch
@@ -1,0 +1,16 @@
+diff --git a/src/Hooks/SetupAfterCache.php b/src/Hooks/SetupAfterCache.php
+index 169bfa5..3d2c002 100644
+--- a/src/Hooks/SetupAfterCache.php
++++ b/src/Hooks/SetupAfterCache.php
+@@ -92,9 +92,9 @@ class SetupAfterCache {
+ 	 */
+ 	protected function setInstallPaths() {
+ 		$this->configuration[ 'chameleonLocalPath' ] =
+-			$this->configuration['wgStyleDirectory'] . '/chameleon';
++			$this->configuration['IP'] . '/canasta-skins/chameleon';
+ 		$this->configuration[ 'chameleonRemotePath' ] =
+-			$this->configuration['wgStylePath'] . '/chameleon';
++			$this->configuration['wgScriptPath'] . '/canasta-skins/chameleon';
+ 	}
+ 
+ 	protected function addLateSettings() {


### PR DESCRIPTION
Changes:
1) Replaced the default path in **Bootstrap** which pointed to "extensions/" instead of "canasta-extensions/"
2) Replaced the default path in **chameleon** which pointed to "skins/" instead of "canasta-skins/"