### PR TITLE
Updates msmtp configuration & configuration file location

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -660,7 +660,7 @@ ENV MW_ENABLE_JOB_RUNNER=true \
 	LOG_FILES_COMPRESS_DELAY=3600 \
 	LOG_FILES_REMOVE_OLDER_THAN_DAYS=10
 
-COPY _sources/configs/.msmtprc /etc/
+COPY _sources/configs/msmtprc /etc/
 COPY _sources/configs/mediawiki.conf /etc/apache2/sites-enabled/
 COPY _sources/configs/status.conf /etc/apache2/mods-available/
 COPY _sources/configs/php_error_reporting.ini _sources/configs/php_upload_max_filesize.ini /etc/php/7.4/cli/conf.d/

--- a/_sources/configs/.msmtprc
+++ b/_sources/configs/.msmtprc
@@ -8,13 +8,12 @@ account default
 # The SMTP smarthost
 host 172.17.0.1
 
-# Use TLS on port 465
-port 465
-tls on
+port 25
+tls off
 tls_starttls off
 
 # Construct envelope-from addresses of the form "user@oursite.example"
-#auto_from on
+auto_from on
 #maildomain oursite.example
 
 # Syslog logging with facility LOG_MAIL instead of the default LOG_USER


### PR DESCRIPTION
It was noticed that on debian the  `msmtp`  is looking for the configuration path at `/etc/msmtprc` and not `/etc/.msmtprc`