### PR TITLE
Run /monitor-directories.sh script as root user

### DIFF
--- a/_sources/scripts/monitor-directories.sh
+++ b/_sources/scripts/monitor-directories.sh
@@ -9,29 +9,29 @@ userskins="$MW_HOME/user-skins"
 skins="$MW_HOME/skins"
 canskins="$MW_HOME/canasta-skins"
 
-#  - Detects activity changes inside user-extensions and user-skins.                           
-#  - Adds symlinks from the those folders to the appropriate correspondent folders, user-extensions to extensions and user-skins to skins. 				       
+#  - Detects activity changes inside user-extensions and user-skins.
+#  - Adds symlinks from the those folders to the appropriate correspondent folders, user-extensions to extensions and user-skins to skins.
 #  - As a fallback, the moment the extension is removed or moved from user-extensions it will revert back by adding a symlink to the extension
-#    located in canasta-extensions.  
+#    located in canasta-extensions.
 
-inotifywait -m -e create,moved_to,delete,moved_from --format '%e:%f%0' -- "$userexts" | 
-	while IFS=: read -r event file; do 
-		case $event in 
-			CREATE,ISDIR|MOVED_TO,ISDIR) 
-				ln -rsft "$extensions" -- "$userexts"/"$file" ;; 
-			DELETE,ISDIR|MOVED_FROM,ISDIR) 
-				echo "event: ${event} file: ${file}"; 
+inotifywait -m -e create,moved_to,delete,moved_from --format '%e:%f' -- "$userexts" |
+	while IFS=: read -r event file; do
+		case $event in
+			CREATE,ISDIR|MOVED_TO,ISDIR)
+				ln -rsft "$extensions" -- "$userexts"/"$file" ;;
+			DELETE,ISDIR|MOVED_FROM,ISDIR)
+				echo "event: ${event} file: ${file}";
 				ln -rsft "$extensions" -- "$canexts"/"$file" || rm -- "$file";
-		esac 
+		esac
 	done
 
-inotifywait -m -e create,moved_to,delete,moved_from --format '%e:%f%0' -- "$userskins" | 
-	while IFS=: read -r event file; do 
-		case $event in 
-			CREATE,ISDIR|MOVED_TO,ISDIR) 
-				ln -rsft skins -- "$userskins"/"$file" ;; 
-			DELETE,ISDIR|MOVED_FROM,ISDIR) 
-				echo "event: ${event} file: ${file}"; 
-				ln -rsft skins -- "$canskins"/"$file" || rm -- "$file"; 
-		esac 
+inotifywait -m -e create,moved_to,delete,moved_from --format '%e:%f' -- "$userskins" |
+	while IFS=: read -r event file; do
+		case $event in
+			CREATE,ISDIR|MOVED_TO,ISDIR)
+				ln -rsft skins -- "$userskins"/"$file" ;;
+			DELETE,ISDIR|MOVED_FROM,ISDIR)
+				echo "event: ${event} file: ${file}";
+				ln -rsft skins -- "$canskins"/"$file" || rm -- "$file";
+		esac
 	done

--- a/_sources/scripts/run-apache.sh
+++ b/_sources/scripts/run-apache.sh
@@ -166,7 +166,7 @@ check_mount_points () {
 }
 
 inotifywait() {
-	runuser -c /monitor-directories.sh -s /bin/bash "$WWW_USER"	
+	/monitor-directories.sh
 }
 
 # Wait db


### PR DESCRIPTION
The script can't create the symlinks as the web user, it outputs:
```
web_1            | + case $event in
web_1            | + ln -rsft /var/www/mediawiki/w/extensions -- /var/www/mediawiki/w/user-extensions/test%0
web_1            | ln: failed to create symbolic link '/var/www/mediawiki/w/extensions/test%0': Permission denied
```