### PR TITLE
Add psr/http-message requirement to composer.canasta.json

### DIFF
--- a/_sources/configs/composer.canasta.json
+++ b/_sources/configs/composer.canasta.json
@@ -1,4 +1,7 @@
 {
+	"require": {
+		"psr/http-message": "1.1"
+	},
 	"extra": {
 		"merge-plugin": {
 			"include": [


### PR DESCRIPTION
To ensure that the best version of this library is downloaded, given conflicting requirements by different extensions. As suggested by @cicalese.