### PR TITLE
Updates SWL version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -502,7 +502,7 @@ RUN set -x; \
 	# SemanticWatchlist (v. 1.3.0)
 	&& git clone https://github.com/SemanticMediaWiki/SemanticWatchlist.git $MW_HOME/extensions/SemanticWatchlist \
 	&& cd $MW_HOME/extensions/SemanticWatchlist \
-	&& git checkout -q 417851c22c25f3e33fb654f4138c760c53051b9a \
+	&& git checkout -q ecea17097874d16cd240ce35bd20692a67c5064b \
 	# SimpleBatchUpload (v. 2.0.0)
 	&& git clone https://github.com/ProfessionalWiki/SimpleBatchUpload $MW_HOME/extensions/SimpleBatchUpload \
 	&& cd $MW_HOME/extensions/SimpleBatchUpload \


### PR DESCRIPTION
Upgrades SemanticWatchlist to commit `ecea17097874d16cd240ce35bd20692a67c5064b`

This commit includes fix for MailAddress calls, otherwise SWL is unable to send emails at 1.39+