### PR TITLE
Special:Random is cached

### DIFF
--- a/_sources/configs/default.vcl
+++ b/_sources/configs/default.vcl
@@ -54,7 +54,12 @@ sub vcl_recv {
     if (req.url ~ "/w/api.php") {
         return(pass);
     }
-    
+
+    # Bypass cache for "Special:Random"
+    if (req.url ~ "^/(w/index\.php\?title=|wiki/)Special:Random") {
+        return (pass);
+    }
+
     call mobile_detect;
 
     # Pass requests from logged-in users directly.


### PR DESCRIPTION
## Describe the bug
**Summary**: The redirect sent by Special:Random is cached

**Description**: Visiting Special:Random initially provides a random page.   Subsequent visits to the page result in the same redirect.  Adding a param (_e.g.,_ <tt>?t=5</tt>) directs you to a new page but subsequent visits to Special:Random?t=5 end up on the same page.

## Expected behavior
A new page every time Special:Random is visited.
