### PR TITLE
Adds AWS extension and auto-configuration settings

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -160,6 +160,10 @@ RUN set -x; \
 	&& git clone --single-branch -b $MW_VERSION https://github.com/wikimedia/mediawiki-extensions-Arrays $MW_HOME/extensions/Arrays \
 	&& cd $MW_HOME/extensions/Arrays \
 	&& git checkout -q 338f661bf0ab377f70e029079f2c5c5b370219df \
+	# AWS
+	&& git clone --single-branch -b master https://github.com/edwardspec/mediawiki-aws-s3.git $MW_HOME/extensions/AWS \
+	&& cd $MW_HOME/extensions/AWS \
+	&& git checkout -q 97c210475f82ed5bc86ea3cbf2726162ccbedbfe \
 	# BetaFeatures
 	&& git clone --single-branch -b $MW_VERSION https://github.com/wikimedia/mediawiki-extensions-BetaFeatures $MW_HOME/extensions/BetaFeatures \
 	&& cd $MW_HOME/extensions/BetaFeatures \

--- a/_sources/canasta/CanastaDefaultSettings.php
+++ b/_sources/canasta/CanastaDefaultSettings.php
@@ -70,6 +70,47 @@ $wgCdnServersNoPurge[] = '10.0.0.0/8';     // 10.0.0.0 – 10.255.255.255
 $wgCdnServersNoPurge[] = '172.16.0.0/12';  // 172.16.0.0 – 172.31.255.255
 $wgCdnServersNoPurge[] = '192.168.0.0/16'; // 192.168.0.0 – 192.168.255.255
 
+# Auto-configuration for AWS extension QLOUD-122
+if ( !empty( getenv( 'AWS_IMAGES_BUCKET' ) ) ) {
+	// see https://github.com/edwardspec/mediawiki-aws-s3
+	wfLoadExtension( 'AWS' );
+	$wgAWSCredentials = [
+		'key' => getenv( 'AWS_IMAGES_ACCESS' ),
+		'secret' => getenv( 'AWS_IMAGES_SECRET' ),
+		'token' => false
+	];
+	$wgAWSRegion = getenv( 'AWS_IMAGES_REGION' ); #eu-west-2
+	$wgAWSBucketName = getenv( 'AWS_IMAGES_BUCKET' );
+	if ( !empty( getenv( 'AWS_IMAGES_BUCKET_DOMAIN' ) ) ) {
+		// $1.s3.eu-west-2.amazonaws.com, $1 is replaced with bucket name
+		$wgAWSBucketDomain = getenv( 'AWS_IMAGES_BUCKET_DOMAIN' );
+	}
+	$wgFileBackends['s3']['privateWiki'] = false;
+	// see https://github.com/edwardspec/mediawiki-aws-s3/blob/97c210475f82ed5bc86ea3cbf2726162ccbedbfe/s3/AmazonS3FileBackend.php#L97
+	// if true, then all S3 objects are private and uploaded with appropriate ACLs.
+	// for images to work in private mode, $wgUploadPath should point to img_auth.php
+	if ( !empty( getenv( 'AWS_IMAGES_PRIVATE' ) ) ) {
+		$wgFileBackends['s3']['privateWiki'] = true;
+	}
+	if ( !empty( getenv( 'AWS_IMAGES_ENDPOINT' ) ) ) {
+		$wgFileBackends['s3']['endpoint'] = getenv( 'AWS_IMAGES_ENDPOINT' );
+	}
+	if ( !empty( getenv( 'AWS_IMAGES_SUBDIR' ) ) ) {
+		// i.e. '/subdir'
+		$wgAWSBucketTopSubdirectory = getenv( 'AWS_IMAGES_SUBDIR' );
+	}
+
+	// some software (such as MinIO) doesn't use subdomains for buckets
+	if ( !empty( getenv( 'AWS_IMAGES_USEPATH') ) ) {
+		$wgFileBackends['s3']['use_path_style_endpoint'] = true;
+	}
+	// see https://github.com/edwardspec/mediawiki-aws-s3?tab=readme-ov-file#migrating-images
+	// this configuration resembles native images storage structure to allow
+	// for seamless migration of existing images to object storage
+	$wgAWSRepoHashLevels = 2;
+	$wgAWSRepoDeletedHashLevels = 3;
+}
+
 /**
  * Returns boolean value from environment variable
  * Must return the same result as isTrue function in run-apache.sh file

--- a/_sources/configs/composer.canasta.json
+++ b/_sources/configs/composer.canasta.json
@@ -26,7 +26,8 @@
 				"skins/chameleon/composer.json",
 				"extensions/Flow/composer.json",
 				"extensions/Sentry/composer.json",
-				"extensions/MassMessageEmail/composer.json"
+				"extensions/MassMessageEmail/composer.json",
+				"extensions/AWS/composer.json"
 			]
 		}
 	}


### PR DESCRIPTION
Adds https://www.mediawiki.org/wiki/Extension:AWS and configuration support. Introduces the following ENV variables:

- `AWS_IMAGES_BUCKET` bucket name to store the images
- `AWS_IMAGES_ACCESS` access key
- `AWS_IMAGES_SECRET` secret key
- `AWS_IMAGES_REGION` region
- `AWS_IMAGES_BUCKET_DOMAIN` - (optional) custom domain to serve the images, i.e. `$1.s3.eu-west-2.amazonaws.com` where `$1` is replaced by the extension to the bucket name
- `AWS_IMAGES_PRIVATE` - (optional) (default `false`) set to `true` to enable private images for private wikis
- `AWS_IMAGES_ENDPOINT` - (optional) custom S3 endpoint URL
- `AWS_IMAGES_SUBDIR` - (optional) subdirectory to use on the S3 bucket
- `AWS_IMAGES_USEPATH` - (optional) if set forces to use path-style instead of subdomain-style endpoint URL

If the `AWS_IMAGES_BUCKET` is set the `AWS` extension is automatically loaded and enabled