### PR TITLE
Update Recommended Revisions version to remove EasyTimeline extension

### DIFF
--- a/contents.yaml
+++ b/contents.yaml
@@ -1,1 +1,1 @@
-inherits: https://www.mediawiki.org/wiki/Recommended_Revisions/1.43?oldid=7760550&action=raw
+inherits: https://www.mediawiki.org/wiki/Recommended_Revisions/1.43?oldid=7778780&action=raw


### PR DESCRIPTION
EasyTimeline requires more work to install than Canasta currently provides -Canasta would have to additionally install Perl, Ploticus and the FreeSans font.

Relates to #511 .