### PR TITLE
Change to new Recommended Revisions location, update to Maps 12.0.0

### DIFF
--- a/contents.yaml
+++ b/contents.yaml
@@ -1,1 +1,1 @@
-inherits: https://www.mediawiki.org/wiki/Recommended_Revisions/1.43?oldid=7811879&action=raw
+inherits: https://www.mediawiki.org/wiki/Recommended_Revisions/1.43?oldid=7824729&action=raw

--- a/contents.yaml
+++ b/contents.yaml
@@ -1,1 +1,1 @@
-inherits: https://www.mediawiki.org/wiki/Recommended_Revisions/1.43?oldid=7824729&action=raw
+inherits: https://raw.githubusercontent.com/CanastaWiki/RecommendedRevisions/18bdb18e0504ef9442e1bd0484497b34634b5515/1.43.yaml


### PR DESCRIPTION
Fixes #519 . The Recommended Revisions location needed to change because a recent change in "robot policy" on mediawiki.org (and all Wikimedia sites?) meant that the previous download no longer worked.