### PR TITLE
Makes user directories monitoring optional

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -759,7 +759,8 @@ ENV MW_AUTOUPDATE=true \
 	PM_MAX_SPARE_SERVERS=15 \
 	PM_MAX_REQUESTS=2500 \
 	LOG_FILES_COMPRESS_DELAY=3600 \
-	LOG_FILES_REMOVE_OLDER_THAN_DAYS=10
+	LOG_FILES_REMOVE_OLDER_THAN_DAYS=10 \
+	MONITOR_USER_DIRECTORIES=true
 
 COPY _sources/configs/msmtprc /etc/
 COPY _sources/configs/mediawiki.conf /etc/apache2/sites-enabled/

--- a/_sources/scripts/run-apache.sh
+++ b/_sources/scripts/run-apache.sh
@@ -136,7 +136,9 @@ cd "$MW_HOME" || exit
 # It can take a long time and should not block Apache from starting.
 /update-images-permissions.sh &
 
-/monitor-directories.sh &
+if isTrue "$MONITOR_USER_DIRECTORIES"; then
+    /monitor-directories.sh &
+fi
 
 # Run maintenance scripts in background.
 touch "$WWW_ROOT/.maintenance"


### PR DESCRIPTION
- enabled by default
- contolled by `MONITOR_USER_DIRECTORIES` env (default `true`)