### PR TITLE
Checks out MassMessage REL1_39 onto patched version (MassMessageJobBeforeMessageSent hook)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -392,7 +392,8 @@ RUN set -x; \
 	&& cd $MW_HOME/extensions/MassMessage \
 	&& git checkout -q d6a86291bb975c3dc7778f370006f1145cc834bd \
 	# Can be dropped once https://gerrit.wikimedia.org/r/c/mediawiki/extensions/MassMessage/+/1198560 is merged into REL1_39
-	&& git fetch https://gerrit.wikimedia.org/r/mediawiki/extensions/MassMessage refs/changes/60/1198560/1 && git checkout FETCH_HEAD \
+	&& git fetch https://gerrit.wikimedia.org/r/mediawiki/extensions/MassMessage refs/changes/60/1198560/1 \
+  	&& git checkout FETCH_HEAD \
 	# MassMessageEmail
 	&& git clone --single-branch -b $MW_VERSION https://github.com/wikimedia/mediawiki-extensions-MassMessageEmail $MW_HOME/extensions/MassMessageEmail \
 	&& cd $MW_HOME/extensions/MassMessageEmail \


### PR DESCRIPTION
* MassMessage REL1_39 patch that adds the hook https://gerrit.wikimedia.org/r/c/mediawiki/extensions/MassMessage/+/1198560

[MEYE-392]