### PR TITLE
Switches Graph extension from GitHub to Gerrit due to GitHub repo inavailability

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -310,8 +310,8 @@ RUN set -x; \
 	&& git clone --single-branch -b $MW_VERSION https://github.com/wikimedia/mediawiki-extensions-GoogleDocCreator $MW_HOME/extensions/GoogleDocCreator \
 	&& cd $MW_HOME/extensions/GoogleDocCreator \
 	&& git checkout -q 9e53ecfa4149688a2352a7898c2a2005632e1b7d \
-	# Graph
-	&& git clone --single-branch -b $MW_VERSION https://github.com/wikimedia/mediawiki-extensions-Graph $MW_HOME/extensions/Graph \
+	# Graph (the GitHub extension is no longer available)
+	&& git clone --single-branch -b $MW_VERSION https://gerrit.wikimedia.org/r/mediawiki/extensions/Graph $MW_HOME/extensions/Graph \
 	&& cd $MW_HOME/extensions/Graph \
 	&& git checkout -q 9c229eafdf406c95a4a666a6b7f2a9d0d3d682e4 \
 	# GTag


### PR DESCRIPTION
The GitHub repo  is  no  longer  available  and this breaks  the build

[MEYE-392]