### PR TITLE
Fix chameleon dependencies by using Bootstrap 4.6.2

### DIFF
--- a/contents.yaml
+++ b/contents.yaml
@@ -1,1 +1,1 @@
-inherits: https://raw.githubusercontent.com/CanastaWiki/RecommendedRevisions/4f23bae9d3a6d2889caaa46648546082c94e2b64/1.43.yaml
+inherits: https://raw.githubusercontent.com/CanastaWiki/RecommendedRevisions/b4a24d46a803b0d459433224f8fb42a6974ee809/1.43.yaml


### PR DESCRIPTION
Should make our little lizard happy again.