### PR TITLE
Update BASE_IMAGE to canasta-base:1.0.8

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-ARG BASE_IMAGE=ghcr.io/canastawiki/canasta-base:1.0.7
+ARG BASE_IMAGE=ghcr.io/canastawiki/canasta-base:1.0.8
 FROM ${BASE_IMAGE} AS base
 
 LABEL maintainers=""


### PR DESCRIPTION
## Summary

Update the CanastaBase image version to 1.0.8 to include:
- Environment variable support and new config directory structure
- FarmConfigLoader fix to default to first wiki in CLI mode
- Updated run-maintenance-scripts.sh to support new config directory structure

## Related PRs

- CanastaWiki/CanastaBase#59 - Environment variable support and directory structure
- CanastaWiki/Canasta-DockerCompose#77 - Remove SettingsTemplate.php, add numeric prefixes to settings files
- CanastaWiki/Canasta-CLI#161 - Replace SettingsTemplate.php with generated README files

## Merge Order

1. ** CanastaWiki/CanastaBase#59** - merge first
2. Wait for `canasta-base:1.0.8` image to build
3. ** CanastaWiki/Canasta#573** (this PR) - update BASE_IMAGE
4. Wait for `canasta:latest` image to build
5. **Canasta-DockerCompose #77**
6. **Canasta-CLI #161**

**Do not merge until CanastaBase PR #59 is merged and the 1.0.8 image is built.**