### PR TITLE
Remove SMW dirty hack from Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,10 +13,6 @@ RUN php /tmp/extensions-skins.php "/tmp/contents.yaml"
 ENV MW_MAINTENANCE_CIRRUSSEARCH_UPDATECONFIG=2 \
 	MW_MAINTENANCE_CIRRUSSEARCH_FORCEINDEX=2
 
-# Dirty hack for Semantic MediaWiki
-RUN set -x; \
-	sed -i "s/#wfLoadExtension('SemanticMediaWiki');/#enableSemantics('localhost');/g" $MW_ORIGIN_FILES/installedExtensions.txt
-
 # Maintenance scripts for specific extensions
 COPY cirrus-search-maintenance.sh _sources/scripts/maintenance-scripts/
 COPY getSMWSettings.php _sources/canasta/


### PR DESCRIPTION
## Summary
- Remove the `sed` hack that replaced `#wfLoadExtension('SemanticMediaWiki')` with `#enableSemantics('localhost')` in `installedExtensions.txt`
- With the unified composer autoloader (CanastaWiki/CanastaBase#85), `wfLoadExtension('SemanticMediaWiki')` works properly and this hack is no longer needed
- Note: `installedExtensions.txt` only contains MediaWiki core bundled extensions, not Canasta-added ones like SMW, so this sed was a no-op anyway (see CanastaWiki/CanastaBase#88)

Closes #576

**Merge order:** This PR is **2 of 4** — merge after CanastaWiki/CanastaBase#85, then CanastaWiki/Canasta-DockerCompose#91, then CanastaWiki/Canasta-CLI#236.

## Test plan
- [x] Build Canasta image and verify it builds successfully without the sed hack