### PR TITLE
Only publish versioned image tag on Git tag events

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -17,6 +17,9 @@ on:
   # Plus for any pull-requests
   pull_request:
 
+  # Manual trigger (e.g., after CanastaBase is rebuilt)
+  workflow_dispatch:
+
 env:
   IMAGE_NAME: canasta
 
@@ -24,7 +27,7 @@ jobs:
   # Test the image Dockerfile syntax using https://github.com/replicatedhq/dockerfilelint
   test:
     runs-on: ubuntu-latest
-    if: github.event_name == 'push' || github.event_name == 'pull_request'
+    if: github.event_name == 'push' || github.event_name == 'pull_request' || github.event_name == 'workflow_dispatch'
     steps:
       - uses: actions/checkout@v3
 
@@ -36,7 +39,7 @@ jobs:
   push:
     needs: [test]
     runs-on: ubuntu-latest
-    if: github.event_name == 'push' || github.event_name == 'pull_request'
+    if: github.event_name == 'push' || github.event_name == 'pull_request' || github.event_name == 'workflow_dispatch'
     steps:
       - name: Checkout
         uses: actions/checkout@v3
@@ -163,7 +166,7 @@ jobs:
   auto-tag:
     needs: [push]
     runs-on: ubuntu-latest
-    if: github.ref == 'refs/heads/master' && github.event_name == 'push'
+    if: github.ref == 'refs/heads/master' && (github.event_name == 'push' || github.event_name == 'workflow_dispatch')
     steps:
       - uses: actions/checkout@v3
         with:


### PR DESCRIPTION
## Summary

- Remove `$CANASTA_VERSION` from master branch Docker tags so versioned tags (e.g., `3.2.0`) are only published when a Git tag is pushed, making them immutable
- Add auto-tag job: when a master push changes the VERSION file and no Git tag exists for that version, automatically creates one — this triggers a separate workflow run that builds and publishes the immutable versioned Docker image
- Uncomment the `v` prefix strip so both `v3.2.0` and `3.2.0` Git tags produce the same Docker image tag
- Add `workflow_dispatch` trigger so the workflow can be manually run (e.g., to rebuild after CanastaBase is updated) — shows as a "Run workflow" button in the Actions tab
- Master builds continue to get `latest`, `<MW_MAJOR>-latest`, `<MW_VERSION>-latest`, and `<MW_VERSION>-<DATE>-<SHA>` tags

Fixes #586
Part of CanastaWiki/Canasta-CLI#361

## Release process after merge

1. Merge PRs to master as usual (builds get `latest` + date-SHA tags)
2. When ready to release, bump `VERSION` in a final commit
3. The auto-tag job creates `v<VERSION>` and pushes it
4. The tag event triggers a new build that publishes the immutable versioned image (e.g., `3.2.1`)
5. Update `DefaultImageTag` in Canasta-CLI to match and release CLI

## Manual rebuild

After CanastaBase is rebuilt, go to **Actions → Docker build and push → Run workflow** to rebuild Canasta with the updated base image.