### PR TITLE
Use regctl to read MW version label without pulling image

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -41,13 +41,15 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
       -
+        name: Install regctl
+        uses: regclient/actions/regctl-installer@v0.1
+      -
         name: Extract MW_VERSION from CanastaBase labels
         id: extract_mw
         run: |
           set -euo pipefail
           BASE_IMAGE=$(awk -F'=' '/^ARG BASE_IMAGE=/ {print $2}' Dockerfile)
-          docker pull "$BASE_IMAGE" >/dev/null
-          MW_VERSION=$(docker inspect --format '{{ index .Config.Labels "wiki.canasta.mediawiki.version" }}' "$BASE_IMAGE")
+          MW_VERSION=$(regctl image config "$BASE_IMAGE" | jq -r '.config.Labels["wiki.canasta.mediawiki.version"]')
           echo "MW_VERSION=$MW_VERSION"
           echo "MW_VERSION=$MW_VERSION" >> $GITHUB_ENV
 


### PR DESCRIPTION
## Summary

- Replace `docker pull` + `docker inspect` with `regctl image config` to extract the `wiki.canasta.mediawiki.version` label from CanastaBase
- Reads the label directly from the registry manifest (~KB) instead of downloading the full ~700MB image, reducing the step from ~30s to a few seconds
- Uses [regclient](https://github.com/regclient/regclient) (~1.7k stars, actively maintained), which handles registry auth and manifest negotiation internally — simpler and more robust than raw API calls

Closes #554