### PR TITLE
Fix CI to publish Canasta version tag

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -40,6 +40,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v3
+        with:
+          fetch-depth: 2
       -
         name: Install regctl
         uses: regclient/actions/regctl-installer@v0.1


### PR DESCRIPTION
## Summary
- Add `fetch-depth: 2` to the checkout step in the Docker build workflow so that `git diff HEAD~1` can detect VERSION file changes
- Without this, the shallow clone has no parent commit, so the version tag (e.g., `3.3.1`) is never published to `ghcr.io/canastawiki/canasta`

Fixes #599