### PR TITLE
Bundle CreateUserPage extension

### DIFF
--- a/contents.yaml
+++ b/contents.yaml
@@ -1,1 +1,1 @@
-inherits: https://raw.githubusercontent.com/CanastaWiki/RecommendedRevisions/00e92199d2e119efac0d0173f0946000fffb7295/1.43.yaml
+inherits: https://raw.githubusercontent.com/CanastaWiki/RecommendedRevisions/5ec35b2d7de30580dc82485cf71f76cb0d565c62/1.43.yaml


### PR DESCRIPTION
Bundles the [CreateUserPage](https://www.mediawiki.org/wiki/Extension:Create_User_Page) extension by bumping the RecommendedRevisions pin in `contents.yaml` to include it (CanastaWiki/RecommendedRevisions#15, merged).

The only change between the old and new pin is the addition of CreateUserPage; no other extensions are affected.

Closes #638