### PR TITLE
Update TemplateStyles to fix css-sanitizer conflict (#645)

### DIFF
--- a/contents.yaml
+++ b/contents.yaml
@@ -1,1 +1,1 @@
-inherits: https://raw.githubusercontent.com/CanastaWiki/RecommendedRevisions/5ec35b2d7de30580dc82485cf71f76cb0d565c62/1.43.yaml
+inherits: https://raw.githubusercontent.com/CanastaWiki/RecommendedRevisions/d9aa1917f8429831e1a73cebded3b45b39d1a907/1.43.yaml


### PR DESCRIPTION
Fixes #645.

MediaWiki 1.43.9 (shipped in 3.5.11) bumped `wikimedia/css-sanitizer` to `6.2.1`, but the RecommendedRevisions-pinned TemplateStyles still required `^5.x`. The unified `composer update` during the image build couldn't resolve, installed **none** of the merged extension dependencies, and shipped a broken `vendor/` (222 packages vs 3.5.10's 378) — fatal `Class "Elastica\Client" not found` / `Class "SMW\Setup" not found` for any wiki using a bundled Composer extension.

This advances the `contents.yaml` RecommendedRevisions `inherits` pin to `d9aa191` (CanastaWiki/RecommendedRevisions#18, merged), which moves TemplateStyles to a `wikimedia/css-sanitizer ^6.0.0` commit.

**Verified:** with the new TemplateStyles `composer.json`, `composer update` resolves cleanly in a `canasta:3.5.11` container (`202 installs`), including `ruflin/elastica (7.3.1)` and `data-values/data-values (3.1.1)`.

The version bumps (Canasta `VERSION` → 3.5.12 and the CanastaBase base-image bump) are in the separate release PR #648. Merge this content fix first so the published 3.5.12 image contains it.
