### PR TITLE
Update contents.yaml - fixes for YAML file errors for five extensions

### DIFF
--- a/contents.yaml
+++ b/contents.yaml
@@ -1,1 +1,1 @@
-inherits: https://raw.githubusercontent.com/CanastaWiki/RecommendedRevisions/d9aa1917f8429831e1a73cebded3b45b39d1a907/1.43.yaml
+inherits: https://raw.githubusercontent.com/CanastaWiki/RecommendedRevisions/3a3876f6228eacf7842f705f146da590998688ee/1.43.yaml


### PR DESCRIPTION
WhosOnline and WSOAuth were using the wrong branch (1_43 instead of master), EmbedVideo was on the wrong branch and an un-ideal commit; SyntaxHighlight_GeSHi had the wrong name (missing a "_GeSHi", though it wasn't a big problem), and Semantic MediaWiki had a "persistent directory" that was no longer in use.