### PR TITLE
Preserve empty TSV fields when parsing rescan findings

### DIFF
--- a/.github/workflows/rescan-published-images.yml
+++ b/.github/workflows/rescan-published-images.yml
@@ -205,7 +205,10 @@ jobs:
                 | .[]
                 | @tsv
               ' "$RESULT" |
-                while IFS=$'\t' read -r SEVERITY VULNERABILITY PACKAGE INSTALLED FIXED CLASS TARGET; do
+                # Split on a non-whitespace delimiter: tab is IFS whitespace, so an
+                # empty FixedVersion collapses and shifts every later field left.
+                tr '\t' '\037' |
+                while IFS=$'\037' read -r SEVERITY VULNERABILITY PACKAGE INSTALLED FIXED CLASS TARGET; do
                   EXTENSION=""
                   if EXTENSION_FROM_TARGET=$(extract_extension_from_target "$TARGET"); then
                     EXTENSION="$EXTENSION_FROM_TARGET"


### PR DESCRIPTION
Tab is IFS *whitespace*, so bash collapses consecutive tabs into a single delimiter even with `IFS` set explicitly to tab. An OS package with no available fix emits an empty `FixedVersion`; that field disappears and every later field shifts left one — `FIXED` receives the Trivy class, `CLASS` receives the target, `TARGET` empties.

```
in:  CRITICAL <tab> CVE-2023-45853 <tab> zlib1g <tab> 1:1.2.13.dfsg-1 <tab><tab> os-pkgs <tab> /target/path
out: FIXED=[os-pkgs]  CLASS=[/target/path]  TARGET=[]
```

Two consequences, both defeating what #675 set out to do:

- The fixable filter tests `$7 != ""`, saw `os-pkgs`, and counted every *unfixed* OS finding as fixable — #667's headline said 105 against a true 8. The per-tag column is computed in jq and never went through `read`, which is why the two numbers disagreed.
- The unfixed-CRITICAL extension section selects on `$7 == ""`, which could never match, so it silently reported nothing — exactly the standing-CRITICAL case it was added to surface.

Translating the tabs to unit separators (`\037`) fixes both: they are not IFS whitespace, so empty fields survive. `@tsv` escapes literal tabs inside values, so none remain to translate.

Verified against both shapes:

```
FIXED=[]     CLASS=[os-pkgs]    TARGET=[/t/p]
FIXED=[2.0]  CLASS=[lang-pkgs]  TARGET=[/w/extensions/Bar/composer.lock]
```

The repo has no test harness for the workflow, so this was checked with `bash -n` plus the standalone pipeline above; the real confirmation is the next scan's headline matching its per-tag column.

Fixes #679