### PR TITLE
Preserve empty TSV fields in the rescan report loops

### DIFF
--- a/.github/workflows/rescan-published-images.yml
+++ b/.github/workflows/rescan-published-images.yml
@@ -278,8 +278,8 @@ jobs:
               echo
               echo '| Digest | Platform | Severity | Vulnerability | Package | Installed | Fixed | Component |'
               echo '| --- | --- | --- | --- | --- | --- | --- | --- |'
-              awk 'NR <= 200' "$FIXABLE" |
-                while IFS=$'\t' read -r DIGEST ARCH SEVERITY VULNERABILITY PACKAGE INSTALLED FIXED EXTENSION; do
+              awk 'NR <= 200' "$FIXABLE" | tr '\t' '\037' |
+                while IFS=$'\037' read -r DIGEST ARCH SEVERITY VULNERABILITY PACKAGE INSTALLED FIXED EXTENSION; do
                   printf '| `%s` | `%s` | %s | `%s` | `%s` | `%s` | `%s` | `%s` |\n' \
                     "$DIGEST" "$ARCH" "$SEVERITY" "$VULNERABILITY" "$PACKAGE" "$INSTALLED" "$FIXED" "$EXTENSION"
                 done
@@ -295,8 +295,8 @@ jobs:
               echo
               echo '| Digest | Platform | Vulnerability | Package | Installed | Component |'
               echo '| --- | --- | --- | --- | --- | --- |'
-              awk 'NR <= 100' "$UNFIXED_CRIT" |
-                while IFS=$'\t' read -r DIGEST ARCH SEVERITY VULNERABILITY PACKAGE INSTALLED FIXED EXTENSION; do
+              awk 'NR <= 100' "$UNFIXED_CRIT" | tr '\t' '\037' |
+                while IFS=$'\037' read -r DIGEST ARCH SEVERITY VULNERABILITY PACKAGE INSTALLED FIXED EXTENSION; do
                   printf '| `%s` | `%s` | `%s` | `%s` | `%s` | `%s` |\n' \
                     "$DIGEST" "$ARCH" "$VULNERABILITY" "$PACKAGE" "$INSTALLED" "$EXTENSION"
                 done


### PR DESCRIPTION
#680 fixed the tab-collapse in the jq → scan loop, but both **report-rendering** loops still parsed findings rows with `IFS=$'\t' read`, so the same defect survived where it does the most damage.

The unfixed-CRITICAL table is selected by `$7 == ""`, so `FIXED` is empty on **every** row of that section and every row collapses:

```
row: … phpspreadsheet <tab> 1.29.12 <tab><tab> DataTransfer
tab-read   -> Component=[]             (FIXED swallowed "DataTransfer")
\037-read  -> Component=[DataTransfer] (FIXED=[])
```

Now that #680 makes that section render at all, its `Component` column would have been blank on every row — the one column that says which extension to escalate, and easy to misread as "attribution doesn't work here" since these are the first rows the section has ever produced.

The fixable table is converted too. It is correct today only because its `$7 != ""` filter guarantees a non-empty field; relying on that invariant is what produced this bug in the first place.

`awk -F '\t'` partitions are left alone — awk does not collapse empty fields (`NF=8`, `$7=[]`).

## Verification

YAML parses; all `run` blocks pass `bash -n`; no `IFS=$'\t' read` remains on findings rows. Both row shapes exercised through the new idiom:

```
unfixed row  -> Fixed=[]        Component=[DataTransfer]
fixable row  -> Fixed=[4.9.11]  Component=[]
```

The real confirmation is the next scheduled scan: the headline should match the per-tag column, and the unfixed-CRITICAL rows should carry populated Components.

Fixes #681
