### PR TITLE
Attribute vendored libraries via foreign-resources.yaml

### DIFF
--- a/.github/workflows/rescan-published-images.yml
+++ b/.github/workflows/rescan-published-images.yml
@@ -132,6 +132,25 @@ jobs:
               fi
             done < "$manifests"
 
+            # Vendored libraries are committed into an extension rather than declared
+            # as a dependency, so they appear in no manifest above. MediaWiki records
+            # them in foreign-resources.yaml, whose purl package names match Trivy's
+            # PkgName. Location varies by extension, so search by name rather than depth.
+            while IFS= read -r -d '' FR_FILE; do
+              FR_REL=${FR_FILE#"$extracted"/}
+              FR_EXT=${FR_REL#*/}
+              FR_EXT=${FR_EXT%%/*}
+              [ -n "$FR_EXT" ] || continue
+              # purl names first; top-level keys cover entries declared without a purl.
+              {
+                grep -oE 'purl: *pkg:npm/[^@[:space:]]+@' "$FR_FILE" 2>/dev/null |
+                  sed -E 's|.*pkg:npm/||; s|@$||'
+                grep -oE '^[A-Za-z0-9_.-]+:$' "$FR_FILE" 2>/dev/null | tr -d ':'
+              } | sort -u | while IFS= read -r FR_PKG; do
+                [ -n "$FR_PKG" ] && printf '%s\t%s\n' "$FR_PKG" "$FR_EXT"
+              done >> "$raw_map"
+            done < <(find "$extracted" -type f -name foreign-resources.yaml -print0)
+
             if [ -s "$raw_map" ]; then
               sort -u "$raw_map" | awk -F '\t' '
                 {


### PR DESCRIPTION
Vendored front-end libraries are committed into an extension rather than declared as a dependency, so they appear in no `composer.json` or `package.json` and the reverse-map left their `Component` blank. `jsuites` (CVE-2021-41086), shipped by PageForms at `libs/foreign/jsuites/jsuites.js`, is the live case in #667 — and Trivy reports it with a generic `Node.js` target, so the path fast-path cannot attribute it either.

MediaWiki records vendored libraries in `foreign-resources.yaml`, and the purl package name is exactly what Trivy reports as `PkgName`:

```yaml
jsuites:
  version: 3.5.4
  purl: pkg:npm/jsuites@3.5.4
```

This indexes those files into the same `package -> owner` map the lookup already consults. No change to the lookup, the report, or the partition logic.

- Located with `find -name foreign-resources.yaml` rather than a depth bound, since the path varies (`libs/foreign/` in PageForms, `resources/lib/` in core).
- Parsed with `grep`/`sed` on the purl lines — no YAML parser, so no new tooling on the runner. Top-level keys are also indexed, covering entries declared without a purl and directory-vs-npm name differences (`jquery.mousewheel` vs `jquery-mousewheel`).
- Unreadable or unexpected files contribute nothing rather than failing the scan.

## Verification

YAML parses; all `run` blocks pass `bash -n`. The map-building was exercised against a simulated extracted tree containing PageForms' real `foreign-resources.yaml`:

```
jsuites -> PageForms
```

with 11 siblings also indexed (jspreadsheet, jstree, leaflet, select2, sortablejs, rateyo, fullcalendar, jquery-mousewheel, …). So this closes an attribution class, not just one finding.

The real confirmation is the next scheduled scan: `jsuites` should render `PageForms` in the Component column instead of blank.

## Not in scope

MediaWiki core has its own `resources/lib/foreign-resources.yaml`. Attributing those to `core` would need the core tree copied out of the image as well, so it is left as a follow-up — core-vendored libraries will still render blank.

## Note on remediation

Vendored findings route differently from declared-dependency ones, which is worth reflecting in #663: a declared dependency is fixed by widening a constraint (DataTransfer's `phpspreadsheet: "5.7.*"`), a vendored one by bumping the `foreign-resources.yaml` entry upstream and re-running `manageForeignResources.php`. Both end in a RecommendedRevisions pin bump, but the upstream ask differs.

Fixes #683
