### PR TITLE
Update Data Transfer, Display Title and CrawlerProtection extensions

### DIFF
--- a/contents.yaml
+++ b/contents.yaml
@@ -1,1 +1,1 @@
-inherits: https://raw.githubusercontent.com/CanastaWiki/RecommendedRevisions/5795b70a8f1380f030a26b81d52d3b5ce638027f/1.43.yaml
+inherits: https://raw.githubusercontent.com/CanastaWiki/RecommendedRevisions/e99327b97cc4aafd4d71e92dd3b1aec8b1da42e0/1.43.yaml


### PR DESCRIPTION
Moves the Recommended Revisions pin from `5795b70` to `e99327b`.

| RR commit | Change |
| --- | --- |
| `f36b2ac` | Data Transfer 1.8.1 |
| `ac3edf5` | Display Title fix for category pages ([RR #31](https://github.com/CanastaWiki/RecommendedRevisions/pull/31)) |
| `e99327b` | CrawlerProtection 1.5.0 ([RR #33](https://github.com/CanastaWiki/RecommendedRevisions/pull/33)) |

CrawlerProtection 1.5.0 is the notable one: the pinned 1.3.0 did not cover special-page filter parameters sent to `index.php` without a `title` parameter. Those requests never resolve to a special page, so `$wgCrawlerProtectedSpecialPages` did not apply, and because each URL is unique they also defeat CDN and reverse-proxy caching — so every one reached the application.

Goes in ahead of the 3.5.19 release PR, which will then carry only the base image pin, `VERSION` and the release note.