### PR TITLE
Update the CrawlerProtection extension

### DIFF
--- a/contents.yaml
+++ b/contents.yaml
@@ -1,1 +1,1 @@
-inherits: https://raw.githubusercontent.com/CanastaWiki/RecommendedRevisions/344e7b3f5fb8fa9b8405d9bfaf9fe3536a8cf4d1/1.43.yaml
+inherits: https://raw.githubusercontent.com/CanastaWiki/RecommendedRevisions/1cddaaac09d3cc1daded014298023dbfc1b7a8b3/1.43.yaml


### PR DESCRIPTION
Moves the Recommended Revisions pin from `344e7b3` to `1cddaaa`.

| RR commit | Change |
| --- | --- |
| `1cddaaa` | CrawlerProtection 1.7.0 ([RR #36](https://github.com/CanastaWiki/RecommendedRevisions/pull/36)) |

CrawlerProtection 1.7.0 over the pinned 1.5.0:

- Protection is skipped in CLI and maintenance context. A maintenance script re-parsing a page that transcludes a protected special page tripped the anonymous-user check and denied itself; this is the only change that affects a wiki configuring nothing.
- `api.php` and `rest.php` entry points can now be protected, via `$wgCrawlerProtectedApiModules` and `$wgCrawlerProtectedRestPaths`. Both default to empty, so they are inert until configured.
- The IP allowlist matches on the canonical request IP, with opt-in `$wgCrawlerProtectionTrustXForwardedFor` for wikis whose proxy is not in `$wgCdnServersNoPurge`, and `$wgCrawlerProtectionTreatTempUsersAsAnon` for temporary accounts.
- New `CrawlerProtectionShouldDeny` hook for a bespoke access policy; denials are marked `noindex,nofollow`; the raw denial text moved to a message key, so it is translatable.

Every new setting defaults to off or empty, and `requires` stays MediaWiki `>= 1.39.4`.

Goes in ahead of the 3.5.20 release PR, which will then carry only the base image pin, `VERSION` and the release note.

Fixes #689
